### PR TITLE
Impr : Allow to have specific port per seed item

### DIFF
--- a/src/MNDiscovery/MasternodeListProvider.js
+++ b/src/MNDiscovery/MasternodeListProvider.js
@@ -23,7 +23,7 @@ const config = require('../config');
  */
 
 class MasternodeListProvider {
-  constructor(seeds, DAPIPort = config.Api.port) {
+  constructor(seeds, defaultDAPIPort = config.Api.port) {
     const seedsIsArray = Array.isArray(seeds);
 
     if (seeds && !seedsIsArray) {
@@ -34,7 +34,7 @@ class MasternodeListProvider {
      * @type Array<Masternode>
      */
     this.masternodeList = seedsIsArray ? seeds.slice() : config.DAPIDNSSeeds.slice();
-    this.DAPIPort = DAPIPort;
+    this.defaultDAPIPort = defaultDAPIPort;
     this.lastUpdateDate = 0;
   }
   /**
@@ -46,7 +46,7 @@ class MasternodeListProvider {
     const randomMasternode = sample(this.masternodeList);
     const MNList = await RPCClient.request({
       host: randomMasternode.ip,
-      port: this.DAPIPort,
+      port: randomMasternode.port || this.defaultDAPIPort,
     }, 'getMNList', {});
     if (!MNList) {
       throw new Error('Failed to fetch masternodes list');


### PR DESCRIPTION
Test missing for now. Just opening to have discussion on this. 

The idea is that right now, when we want to pass a seed list we do not allow to have specifically port being assigned (in case of one running on a different port), and therefore we take a port value that is unique for all of the seeds. 
This modification allow to tune specific port for one or many of the seed, while keeping current behaviour if none is entering. 