### PR TITLE
Remove getTransaction which duplicates getTransactionById

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Client library used to access Dash DAPI endpoints",
   "main": "index.js",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -196,12 +196,6 @@ class DAPIClient {
   getRawBlock(blockHash) { return this.makeRequestToRandomDAPINode('getRawBlock', { blockHash }); }
 
   /**
-   * @param {string} txid - transaction hash
-   * @return {Promise<object>}
-   */
-  getTransaction(txid) { return this.getTransactionById(txid); }
-
-  /**
    * Returns Transactions for a given address or multiple addresses
    * @param address
    * @param {string|string[]} address or array of addresses

--- a/test/integration/api/index.js
+++ b/test/integration/api/index.js
@@ -272,14 +272,6 @@ describe('basicAPIs', () => {
   });
 
   describe('Transaction', () => {
-    it('should return correct getTransaction', async () => {
-      const dapiOutput = await dapiClient.getTransaction(transactionIdSendToAddress.result);
-      const url = `${insightURL}/tx/${transactionIdSendToAddress.result}`;
-      const response = await fetch(url);
-      const value = await response.json();
-      expect(dapiOutput).to.be.deep.equal(value);
-    });
-
     it('should return correct getTransactionById', async () => {
       const dapiOutput = await dapiClient.getTransactionById(transactionIdSendToAddress.result);
       const url = `${insightURL}/tx/${transactionIdSendToAddress.result}`;

--- a/test/perf/async_api_per_node.js
+++ b/test/perf/async_api_per_node.js
@@ -366,30 +366,6 @@ describe("Performance", function () {
     });
 
     describe('Transaction', () => {
-        it("getTransaction", async function it() {
-            this.timeout(timeoutTest);
-            const trxs = await dapiClient.getTransactionsByAddress(faucetAddress);
-            let results = [];
-            for (var i = 0; i < numLoops; i += 1) {
-                const queries = new Array(numRequests);
-                for (let index = 0; index < numRequests; ++index) {
-                    queries[index] = dapiClient.getTransaction(trxs.items[i % trxs.items.length].txid);
-                }
-                await runPromise(queries).then(function (result) {
-                    results.push(result.time);
-                }, function (failure) {
-                    expect(failure, 'Errors found').to.be.undefined;
-                });
-            }
-            expect(spy.callCount).to.be.equal(numLoops * numRequests + 1);
-            expect(results).to.have.lengthOf(numLoops);
-            const result = average(results);
-            expect(result).to.not.be.NaN;
-            expect(result).to.be.a('number');
-            console.log("average:", result);
-
-        });
-
         it("getTransactionById", async function it() {
             this.timeout(timeoutTest);
             const trxs = await dapiClient.getTransactionsByAddress(faucetAddress);

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -468,9 +468,6 @@ describe('api', () => {
           if (method === 'getTransactionById') {
             return validAddressTransactions.items[0];
           }
-          if (method === 'getTransaction') {
-            return validAddressTransactions.items[0];
-          }
           if (method === 'getBlockHeaders') {
             return [validBlockHeader];
           }
@@ -614,13 +611,6 @@ describe('api', () => {
       const totalReceived = await dapi.getAddressTotalSent(validAddressWithOutputs);
       expect(totalReceived).to.be.a('number');
       expect(totalReceived).to.be.equal(validAddressSummary.totalSentSat);
-    });
-  });
-  describe('.tx.getTransaction', () => {
-    it('Should get transaction', async () => {
-      const dapi = new DAPIClient();
-      const transaction = await dapi.getTransaction(validAddressTransactions.items[0].txid);
-      expect(transaction).to.be.deep.equal(validAddressTransactions.items[0]);
     });
   });
   describe('.address.getTransactionsByAddress', () => {


### PR DESCRIPTION
**Issue being fixed or implemented**

methods getTransaction and getTransactionById with the same functionality

**What was done**
removed getTransaction, getTransactionById remained because:

- getTransaction calles getTransactionById
- in dapi rpc method is with the same name getTransactionById
- getTransaction almost never used in the tests

**What has been tested**
unit and integration tests passed

**What needs to be tested**
nothing.