### PR TITLE
Use `npm config` command for Travis build setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
   - MOZ_HEADLESS=1
 
 before_install:
-  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
+  - npm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
 
 install:
   - npm ci


### PR DESCRIPTION
This fixes `Failed to replace env in config: ${NPM_TOKEN}` error during Travis build.