### PR TITLE
test(headless): improve integration by testing against testnet

### DIFF
--- a/integration.spec.js
+++ b/integration.spec.js
@@ -1,0 +1,5 @@
+// This file is used for compiling integration tests with webpack into one file for using with karma
+
+const integrationContext = require.context('./test/integration/testnet', true, /\.js$/);
+
+integrationContext.keys().forEach(integrationContext);

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,12 +5,14 @@ module.exports = (config) => {
     files: [
       './test/dist/dapi-client.min.js',
       './test.spec.js',
+      './integration.spec.js',
     ],
     exclude: [
     ],
     preprocessors: {
       './test/dist/dapi-client.min.js': ['webpack'],
       './test.spec.js': ['webpack'],
+      './integration.spec.js': ['webpack'],
     },
     webpack: {
       mode: 'production',

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
   "scripts": {
     "build": "webpack --display-error-details",
     "lint": "eslint .",
-    "test": "npm run build && npm run test:node && npm run test:firefox",
+    "test": "npm run build && npm run test:node && npm run test:browsers",
     "test:node": "nyc --check-coverage --reporter=html --reporter=text --lines=83 --branches=60 --functions=70 mocha test/src --recursive",
-    "test:firefox": "karma start ./karma.conf.js --browsers FirefoxHeadless --single-run",
+    "test:browsers": "karma start ./karma.conf.js --single-run",
     "test:integration": "mocha './test/integration/*.spec.js' --timeout 240000",
     "check-package": "npm run check-package:name && npm run check-package:version",
     "check-package:name": "test $(jq -r .name package.json) = $(jq -r .name package-lock.json)",

--- a/test/integration/e2e/index.js
+++ b/test/integration/e2e/index.js
@@ -8,8 +8,6 @@ const sinon = require('sinon');
 const { startDapi } = require('@dashevo/dp-services-ctl');
 
 const DashPlatformProtocol = require('@dashevo/dpp');
-const STPacketFactory = require('@dashevo/dpp/lib/stPacket/STPacketFactory');
-const entropy = require('@dashevo/dpp/lib/util/entropy');
 const Document = require('@dashevo/dpp/lib/document/Document');
 
 const {

--- a/test/integration/testnet/index.js
+++ b/test/integration/testnet/index.js
@@ -1,0 +1,40 @@
+const DAPIClient = require('../../../src/index');
+const seeds = [
+  '52.26.165.185',
+  '54.202.56.123',
+  '54.245.133.124',
+].map(ip => ({service: `${ip}:3000`}));
+const datacontracts={
+  'dpns':'2KfMcMxktKimJxAZUeZwYkFUsEcAZhDKEpQs8GMnpUse'
+}
+//TODO: right now onto devnet. Fix me when testnet is up and running.
+describe('E2E tests against testnet', function suite(){
+  this.timeout(20000);
+  let client;
+  before(async () => {
+    client = new DAPIClient({
+      seeds: seeds,
+      timeout: 1000,
+      retries: 5,
+      network: 'testnet'
+    });
+  })
+  it('should be initialized', function () {
+    expect(client).to.exist;
+    expect(client.dpp).to.exist;
+    expect(client.DAPIPort).to.equal(3000);
+    expect(client.nativeGrpcPort).to.equal(3010);
+    expect(client.timeout).to.equal(1000);
+    expect(client.retries).to.equal(5);
+  });
+  it('should getBestBlockHeight', async function () {
+    const bestBlockHeight = await client.getBestBlockHeight();
+    expect(typeof bestBlockHeight).to.be.equal('number');
+    expect(bestBlockHeight).to.be.gt(0);
+  });
+  it('should getDataContract', async function () {
+    const rawContract = await client.getDataContract(datacontracts.dpns);
+    const contractIdFromRawContract = rawContract.toString().substr(rawContract.length-44);
+    expect(contractIdFromRawContract).to.equal(datacontracts.dpns);
+  });
+});

--- a/test/integration/testnet/index.js
+++ b/test/integration/testnet/index.js
@@ -11,6 +11,7 @@ const datacontracts={
 describe('E2E tests against testnet', function suite(){
   this.timeout(20000);
   let client;
+  let bestBlockHash;
   before(async () => {
     client = new DAPIClient({
       seeds: seeds,
@@ -31,6 +32,20 @@ describe('E2E tests against testnet', function suite(){
     const bestBlockHeight = await client.getBestBlockHeight();
     expect(typeof bestBlockHeight).to.be.equal('number');
     expect(bestBlockHeight).to.be.gt(0);
+  });
+  it('should get best block hash', async function () {
+    bestBlockHash = await client.getBestBlockHash();
+    expect(typeof bestBlockHash).to.be.equal('string');
+    expect(bestBlockHash.length).to.equal(64)
+    expect(bestBlockHash.startsWith('0000')).to.equal(true);
+  });
+  it('should get best raw block', async function () {
+    const bestRawBlock = await client.getRawBlock(bestBlockHash);
+    expect(bestRawBlock.startsWith('0000')).to.equal(true);
+  });
+  it('should get an app identity', async function () {
+    const rawIdentity = await client.getIdentity(datacontracts.dpns);
+    expect(rawIdentity.toString().includes(datacontracts.dpns)).to.equal(true);
   });
   it('should getDataContract', async function () {
     const rawContract = await client.getDataContract(datacontracts.dpns);


### PR DESCRIPTION
### Issue being fixed or implemented  

The testing suite of DAPIClient were missing an integration test against our testnet network. This P.R adds that. 
  
### What was done  

- Added very basic test in `test/integration/testnet` (tests getBlockHeight + getDataContract for now)
- Added `integration.spec.js` that includes above file.
- Modified karma.conf file to refers to those on `test:browsers` execution

### Notes

Creating as draft to start the discussion on this addition.
