### PR TITLE
feat: implement basic Core endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-client",
-  "version": "0.9.0-dev.2",
+  "version": "0.9.0-dev.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9002,6 +9002,12 @@
           }
         }
       }
+    },
+    "sinon-chai": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.4.0.tgz",
+      "integrity": "sha512-BpVxsjEkGi6XPbDXrgWUe7Cb1ZzIfxKUbu/MmH5RoUnS7AXpKo3aIYIyQUg0FMvlUL05aPt7VZuAdaeQhEnWxg==",
+      "dev": true
     },
     "slice-ansi": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-client",
-  "version": "0.9.0-dev.2",
+  "version": "0.9.0-dev.3",
   "description": "Client library used to access Dash DAPI endpoints",
   "main": "index.js",
   "dependencies": {
@@ -40,6 +40,7 @@
     "node-fetch": "^2.6.0",
     "nyc": "^15.0.0",
     "sinon": "^8.0.4",
+    "sinon-chai": "^3.4.0",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,6 @@ class DAPIClient {
    * @param {number} [options.timeout=2000] - timeout for connection to the DAPI
    * @param {number} [options.retries=3] - num of retries if there is no response from DAPI node
    * @param {boolean} [options.forceJsonRpc] - use json rpc even when grpc endpoint is available
-   * @param {boolean} [options.forceGRPCWeb] - use json rpc even when grpc endpoint is available
    */
   constructor(options = {}) {
     this.MNDiscovery = new MNDiscovery(options.seeds, options.port);

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const jsutil = require('@dashevo/dashcore-lib').util.js;
 const preconditionsUtil = require('@dashevo/dashcore-lib').util.preconditions;
 const cbor = require('cbor');
 const {
-  // CorePromiseClient,
+  CorePromiseClient,
   PlatformPromiseClient,
   TransactionsFilterStreamPromiseClient,
   TransactionsWithProofsRequest,
@@ -11,6 +11,10 @@ const {
   GetIdentityRequest,
   GetDataContractRequest,
   GetDocumentsRequest,
+  GetBlockRequest,
+  GetStatusRequest,
+  GetTransactionRequest,
+  SendTransactionRequest,
 } = require('@dashevo/dapi-grpc');
 const {
   ApplyStateTransitionResponse,
@@ -30,6 +34,7 @@ class DAPIClient {
    * @param {number} [options.timeout=2000] - timeout for connection to the DAPI
    * @param {number} [options.retries=3] - num of retries if there is no response from DAPI node
    * @param {boolean} [options.forceJsonRpc] - use json rpc even when grpc endpoint is available
+   * @param {boolean} [options.forceGRPCWeb] - use json rpc even when grpc endpoint is available
    */
   constructor(options = {}) {
     this.MNDiscovery = new MNDiscovery(options.seeds, options.port);
@@ -114,6 +119,126 @@ class DAPIClient {
    * @return {Promise<object>}
    */
   getMnListDiff(baseBlockHash, blockHash) { return this.makeRequestToRandomDAPINode('getMnListDiff', { baseBlockHash, blockHash }); }
+
+
+  /**
+   * Get block by height
+   *
+   * @param {number} height
+   * @return {Promise<null|Buffer>}
+   */
+  async getBlockByHeight(height) {
+    const getBlockRequest = new GetBlockRequest();
+    getBlockRequest.setHeight(height);
+
+    const urlToConnect = await this.getGrpcUrl();
+
+    const client = new CorePromiseClient(urlToConnect);
+
+    const response = await client.getBlock(getBlockRequest);
+
+    const blockBinaryArray = response.getBlock();
+
+    let block = null;
+    if (blockBinaryArray) {
+      block = Buffer.from(blockBinaryArray);
+    }
+
+    return block;
+  }
+
+  /**
+   * Get block by hash
+   *
+   * @param {string} hash
+   * @return {Promise<null|Buffer>}
+   */
+  async getBlockByHash(hash) {
+    const getBlockRequest = new GetBlockRequest();
+    getBlockRequest.setHash(hash);
+
+    const urlToConnect = await this.getGrpcUrl();
+
+    const client = new CorePromiseClient(urlToConnect);
+
+    const response = await client.getBlock(getBlockRequest);
+
+    const blockBinaryArray = response.getBlock();
+
+    let block = null;
+    if (blockBinaryArray) {
+      block = Buffer.from(blockBinaryArray);
+    }
+
+    return block;
+  }
+
+  /**
+   * Get Core chain status
+   *
+   * @return {Promise<Object>}
+   */
+  async getStatus() {
+    const getStatusRequest = new GetStatusRequest();
+
+    const urlToConnect = await this.getGrpcUrl();
+
+    const client = new CorePromiseClient(urlToConnect);
+
+    const response = await client.getStatus(getStatusRequest);
+
+    return response.toObject();
+  }
+
+  /**
+   * Get Transaction by ID
+   *
+   * @param {string} id
+   * @return {Promise<null|Buffer>}
+   */
+  async getTransaction(id) {
+    const getTransactionRequest = new GetTransactionRequest();
+    getTransactionRequest.setId(id);
+
+    const urlToConnect = await this.getGrpcUrl();
+
+    const client = new CorePromiseClient(urlToConnect);
+
+    const response = await client.getTransaction(getTransactionRequest);
+
+    const transactionBinaryArray = response.getTransaction();
+
+    let transaction = null;
+    if (transactionBinaryArray) {
+      transaction = Buffer.from(transactionBinaryArray);
+    }
+
+    return transaction;
+  }
+
+  /**
+   * Send Transaction
+   *
+   * @param {Buffer} transaction
+   * @param {Object} [options]
+   * @param {Object} [options.allowHighFees=false]
+   * @param {Object} [options.bypassLimits=false]
+   * @return {string}
+   */
+  async sendTransaction(transaction, options = {}) {
+    const sendTransactionRequest = new SendTransactionRequest();
+    sendTransactionRequest.setTransaction(transaction);
+    sendTransactionRequest.setAllowHighFees(options.allowHighFees || false);
+    sendTransactionRequest.setBypassLimits(options.bypassLimits || false);
+
+    const urlToConnect = await this.getGrpcUrl();
+
+    const client = new CorePromiseClient(urlToConnect);
+
+    const response = await client.sendTransaction(sendTransactionRequest);
+
+    return response.getTransactionId();
+  }
 
   /**
    * Returns UTXO for a given address or multiple addresses (max result 1000)

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -1,6 +1,6 @@
 const sinon = require('sinon');
 const {
-  // CorePromiseClient,
+  CorePromiseClient,
   PlatformPromiseClient,
   TransactionsFilterStreamPromiseClient,
   TransactionsWithProofsRequest,
@@ -8,11 +8,20 @@ const {
   GetIdentityResponse,
   GetDocumentsResponse,
   GetDataContractResponse,
+  GetBlockRequest,
+  GetBlockResponse,
+  GetStatusRequest,
+  GetStatusResponse,
+  GetTransactionRequest,
+  GetTransactionResponse,
+  SendTransactionRequest,
+  SendTransactionResponse,
 } = require('@dashevo/dapi-grpc');
 const chai = require('chai');
 const { EventEmitter } = require('events');
 const DAPIClient = require('../../src/index');
 const chaiAsPromised = require('chai-as-promised');
+const sinonChai = require('sinon-chai');
 const rpcClient = require('../../src/RPCClient');
 const config = require('../../src/config');
 const SMNListFixture = require('../fixtures/mnList');
@@ -28,6 +37,7 @@ const DashPlatformProtocol = require('@dashevo/dpp');
 const getDataContractFixture = require('@dashevo/dpp/lib/test/fixtures/getDataContractFixture');
 
 chai.use(chaiAsPromised);
+chai.use(sinonChai);
 
 const { expect } = chai;
 
@@ -372,6 +382,191 @@ describe('api', () => {
       expect(mnlistdiff.blockHash).to.be.equal(validBlockHash);
       expect(mnlistdiff.deletedMNs).to.be.an('array');
       expect(mnlistdiff.mnList).to.be.an('array');
+    });
+  });
+
+  describe('#getBlockByHeight', () => {
+    let getBlockStub;
+    let height;
+
+    beforeEach(() => {
+      getBlockStub = sinon
+        .stub(CorePromiseClient.prototype, 'getBlock');
+
+      height = 1;
+    });
+
+    afterEach(() => {
+      getBlockStub.restore();
+    });
+
+    it('should return a block as Buffer', async () => {
+      const response = new GetBlockResponse();
+      response.setBlock(Buffer.from('block'));
+      getBlockStub.resolves(response);
+
+      const request = new GetBlockRequest();
+      request.setHeight(height);
+
+      const client = new DAPIClient();
+      const result = await client.getBlockByHeight(height);
+
+      expect(getBlockStub).to.be.calledOnceWithExactly(request);
+
+      expect(result).to.be.instanceof(Buffer);
+    });
+  });
+
+  describe('#getBlockByHash', () => {
+    let getBlockStub;
+    let hash;
+
+    beforeEach(() => {
+      getBlockStub = sinon
+        .stub(CorePromiseClient.prototype, 'getBlock');
+
+      hash = '4f46066bd50cc2684484407696b7949e82bd906ea92c040f59a97cba47ed8176';
+    });
+
+    afterEach(() => {
+      getBlockStub.restore();
+    });
+
+    it('should return a block as Buffer', async () => {
+      const response = new GetBlockResponse();
+      response.setBlock(Buffer.from('block'));
+      getBlockStub.resolves(response);
+
+      const request = new GetBlockRequest();
+      request.setHash(hash);
+
+      const client = new DAPIClient();
+      const result = await client.getBlockByHash(hash);
+
+      expect(getBlockStub).to.be.calledOnceWithExactly(request);
+
+      expect(result).to.be.instanceof(Buffer);
+    });
+  });
+
+  describe('#getStatus', () => {
+    let getStatusStub;
+
+    beforeEach(() => {
+      getStatusStub = sinon
+        .stub(CorePromiseClient.prototype, 'getStatus');
+    });
+
+    afterEach(() => {
+      getStatusStub.restore();
+    });
+
+    it('should return status as plain object', async () => {
+      const status = {
+        coreVersion: 1,
+        protocolVersion: 2,
+        blocks: 3,
+        timeOffset: 4,
+        connections: 5,
+        proxy: 'proxy',
+        difficulty: 0.4344343,
+        testnet: true,
+        relayFee: 0.1321321,
+        errors: '',
+        network: 'mainnet',
+      };
+
+      const response = new GetStatusResponse();
+      response.setCoreVersion(status.coreVersion);
+      response.setProtocolVersion(status.protocolVersion);
+      response.setBlocks(status.blocks);
+      response.setTimeOffset(status.timeOffset);
+      response.setConnections(status.connections);
+      response.setProxy(status.proxy);
+      response.setDifficulty(status.difficulty);
+      response.setTestnet(status.testnet);
+      response.setRelayFee(status.relayFee);
+      response.setErrors(status.errors);
+      response.setNetwork(status.network);
+
+      getStatusStub.resolves(response);
+
+      const request = new GetStatusRequest();
+
+      const client = new DAPIClient();
+      const result = await client.getStatus();
+
+      expect(getStatusStub).to.be.calledOnceWithExactly(request);
+
+      expect(result).to.be.deep.equal(status);
+    });
+  });
+
+  describe('#getTransaction', () => {
+    let getTransactionStub;
+    let id;
+
+    beforeEach(() => {
+      getTransactionStub = sinon
+        .stub(CorePromiseClient.prototype, 'getTransaction');
+
+      id = '4f46066bd50cc2684484407696b7949e82bd906ea92c040f59a97cba47ed8176';
+    });
+
+    afterEach(() => {
+      getTransactionStub.restore();
+    });
+
+    it('should return a transaction as Buffer', async () => {
+      const response = new GetTransactionResponse();
+      response.setTransaction(Buffer.from('transaction'));
+      getTransactionStub.resolves(response);
+
+      const request = new GetTransactionRequest();
+      request.setId(id);
+
+      const client = new DAPIClient();
+      const result = await client.getTransaction(id);
+
+      expect(getTransactionStub).to.be.calledOnceWithExactly(request);
+
+      expect(result).to.be.instanceof(Buffer);
+    });
+  });
+
+  describe('#sendTransaction', () => {
+    let sendTransactionStub;
+    let transaction;
+    let id;
+
+    beforeEach(() => {
+      sendTransactionStub = sinon
+        .stub(CorePromiseClient.prototype, 'sendTransaction');
+
+      transaction = Buffer.from('transaction');
+      id = '4f46066bd50cc2684484407696b7949e82bd906ea92c040f59a97cba47ed8176';
+    });
+
+    afterEach(() => {
+      sendTransactionStub.restore();
+    });
+
+    it('should return a transaction as Buffer', async () => {
+      const response = new SendTransactionResponse();
+      response.setTransactionId(id);
+      sendTransactionStub.resolves(response);
+
+      const request = new SendTransactionRequest();
+      request.setTransaction(transaction);
+      request.setAllowHighFees(true);
+      request.setBypassLimits(false);
+
+      const client = new DAPIClient();
+      const result = await client.sendTransaction(transaction, { allowHighFees: true });
+
+      expect(sendTransactionStub).to.be.calledOnceWithExactly(request);
+
+      expect(result).to.equal(id);
     });
   });
 


### PR DESCRIPTION
Implement basic Core DAPI endpoints:
 - `getBlock`
 - `getStatus`
 - `getTransaction`
 - `sendTransaction`
- `getBlockByHeight`
- `getBlockByHash`

BREAKING CHANGES: previous `sendRawTransaction` is now called `sendTransaction`