### PR TITLE
doc: jsdoc formatting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ class DAPIClient {
    *
    * @param {string} baseBlockHash - hash or height of start block
    * @param {string} blockHash - hash or height of end block
-   * @return {Promise<object>}
+   * @returns {Promise<object>}
    */
   getMnListDiff(baseBlockHash, blockHash) {
     return this.transportManager.get(TransportManager.JSON_RPC)
@@ -131,7 +131,7 @@ class DAPIClient {
    * Get block by height
    *
    * @param {number} height
-   * @return {Promise<null|Buffer>}
+   * @returns {Promise<null|Buffer>}
    */
   async getBlockByHeight(height) {
     const getBlockRequest = new GetBlockRequest();
@@ -161,7 +161,7 @@ class DAPIClient {
    * Get block by hash
    *
    * @param {string} hash
-   * @return {Promise<null|Buffer>}
+   * @returns {Promise<null|Buffer>}
    */
   async getBlockByHash(hash) {
     const getBlockRequest = new GetBlockRequest();
@@ -190,7 +190,7 @@ class DAPIClient {
   /**
    * Get Core chain status
    *
-   * @return {Promise<Object>}
+   * @returns {Promise<object>}
    */
   async getStatus() {
     const getStatusRequest = new GetStatusRequest();
@@ -208,7 +208,7 @@ class DAPIClient {
    * Get Transaction by ID
    *
    * @param {string} id
-   * @return {Promise<null|Buffer>}
+   * @returns {Promise<null|Buffer>}
    */
   async getTransaction(id) {
     const getTransactionRequest = new GetTransactionRequest();
@@ -246,6 +246,7 @@ class DAPIClient {
    * @param {object} [options]
    * @param {object} [options.allowHighFees=false]
    * @param {object} [options.bypassLimits=false]
+   * @returns {string}
    */
   async sendTransaction(transaction, options = {}) {
     const sendTransactionRequest = new SendTransactionRequest();
@@ -441,7 +442,7 @@ class DAPIClient {
    * @param {number} options.limit - how many objects to fetch
    * @param {number} options.startAt - number of objects to skip
    * @param {number} options.startAfter - exclusive skip
-   * @return {Promise<Buffer[]>}
+   * @returns {Promise<Buffer[]>}
    */
   async getDocuments(contractId, type, options) {
     const {

--- a/src/index.js
+++ b/src/index.js
@@ -20,15 +20,15 @@ const TransportManager = require('./transport/TransportManager');
 const config = require('./config');
 const { responseErrorCodes } = require('./constants');
 
-  /**
-   * @param options
+/**
+ * @param options
  * @param {Array<object>} [options.seeds] - seeds. If no seeds provided
-   * default seed will be used.
-   * @param {number} [options.port=3000] - default port for connection to the DAPI
-   * @param {number} [options.nativeGrpcPort=3010] - Native GRPC port for connection to the DAPI
-   * @param {number} [options.timeout=2000] - timeout for connection to the DAPI
-   * @param {number} [options.retries=3] - num of retries if there is no response from DAPI node
-   */
+ * default seed will be used.
+ * @param {number} [options.port=3000] - default port for connection to the DAPI
+ * @param {number} [options.nativeGrpcPort=3010] - Native GRPC port for connection to the DAPI
+ * @param {number} [options.timeout=2000] - timeout for connection to the DAPI
+ * @param {number} [options.retries=3] - num of retries if there is no response from DAPI node
+ */
 class DAPIClient {
   constructor(options = {}) {
     this.MNDiscovery = new MNDiscovery(options.seeds, options.port);

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ class DAPIClient {
   /* Layer 1 commands */
   /**
    * ONLY FOR TESTING PURPOSES WITH REGTEST. WILL NOT WORK ON TESTNET/LIVENET.
+   *
    * @param {number} blocksNumber - Number of blocks to generate
    * @param {string} address - The address that will receive the newly generated Dash
    * @returns {Promise<string[]>} - block hashes
@@ -65,6 +66,7 @@ class DAPIClient {
 
   /**
    * Returns block hash of chaintip
+   *
    * @returns {Promise<string>}
    */
   getBestBlockHash() {
@@ -77,6 +79,7 @@ class DAPIClient {
 
   /**
    * Returns block hash for the given height
+   *
    * @param {number} height
    * @returns {Promise<string>} - block hash
    */
@@ -90,6 +93,7 @@ class DAPIClient {
 
   /**
    * Get deterministic masternodelist diff
+   *
    * @param {string} baseBlockHash - hash or height of start block
    * @param {string} blockHash - hash or height of end block
    * @return {Promise<object>}
@@ -104,6 +108,7 @@ class DAPIClient {
 
   /**
    * Returns a summary (balance, txs) for a given address
+   *
    * @param {string|string[]} address or array of addresses
    * @param {boolean} [noTxList=false] - true if a list of all txs should NOT be included in result
    * @param {number} [from] - start of range for the tx to be included in the tx list
@@ -260,6 +265,7 @@ class DAPIClient {
 
   /**
    * Returns UTXO for a given address or multiple addresses (max result 1000)
+   *
    * @param {string|string[]} address or array of addresses
    * @param {number} [from] - start of range in the ordered list of latest UTXO (optional)
    * @param {number} [to] - end of range in the ordered list of latest UTXO (optional)
@@ -355,6 +361,7 @@ class DAPIClient {
 
   /**
    * Fetch the identity by id
+   *
    * @param {string} id
    * @returns {Promise<!Buffer|null>}
    */
@@ -389,6 +396,7 @@ class DAPIClient {
 
   /**
    * Fetch Data Contract by id
+   *
    * @param {string} contractId
    * @returns {Promise<Buffer>}
    */
@@ -425,6 +433,7 @@ class DAPIClient {
 
   /**
    * Fetch Documents from Drive
+   *
    * @param {string} contractId
    * @param {string} type - Dap objects type to fetch
    * @param options

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,6 @@ const TransportManager = require('./transport/TransportManager');
 const config = require('./config');
 const { responseErrorCodes } = require('./constants');
 
-class DAPIClient {
   /**
    * @param options
  * @param {Array<object>} [options.seeds] - seeds. If no seeds provided
@@ -30,6 +29,7 @@ class DAPIClient {
    * @param {number} [options.timeout=2000] - timeout for connection to the DAPI
    * @param {number} [options.retries=3] - num of retries if there is no response from DAPI node
    */
+class DAPIClient {
   constructor(options = {}) {
     this.MNDiscovery = new MNDiscovery(options.seeds, options.port);
     this.DAPIPort = options.port || config.Api.port;

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ const { responseErrorCodes } = require('./constants');
 class DAPIClient {
   /**
    * @param options
-   * @param {Array<Object>} [options.seeds] - seeds. If no seeds provided
+ * @param {Array<object>} [options.seeds] - seeds. If no seeds provided
    * default seed will be used.
    * @param {number} [options.port=3000] - default port for connection to the DAPI
    * @param {number} [options.nativeGrpcPort=3010] - Native GRPC port for connection to the DAPI
@@ -115,7 +115,7 @@ class DAPIClient {
    * @param {number} [to] - end of range for the tx to be included in the tx list
    * @param {number} [fromHeight] - which height to start from (optional, overriding from/to)
    * @param {number} [toHeight] - on which height to end (optional, overriding from/to)
-   * @returns {Promise<Object>} - an object with basic address info
+   * @returns {Promise<object>} - an object with basic address info
    */
   getAddressSummary(address, noTxList, from, to, fromHeight, toHeight) {
     return this.transportManager.get(TransportManager.JSON_RPC).makeRequest(
@@ -243,10 +243,9 @@ class DAPIClient {
    * Send Transaction
    *
    * @param {Buffer} transaction
-   * @param {Object} [options]
-   * @param {Object} [options.allowHighFees=false]
-   * @param {Object} [options.bypassLimits=false]
-   * @return {string}
+   * @param {object} [options]
+   * @param {object} [options.allowHighFees=false]
+   * @param {object} [options.bypassLimits=false]
    */
   async sendTransaction(transaction, options = {}) {
     const sendTransactionRequest = new SendTransactionRequest();
@@ -287,7 +286,7 @@ class DAPIClient {
 
   /* txFilterStream methods */
   /**
-   * @param {Object} bloomFilter
+   * @param {object} bloomFilter
    * @param {Uint8Array|Array} bloomFilter.vData - The filter itself is simply a bit
    * field of arbitrary byte-aligned size. The maximum size is 36,000 bytes.
    * @param {number} bloomFilter.nHashFuncs - The number of hash functions to use in this filter.
@@ -296,7 +295,7 @@ class DAPIClient {
    * hash function used by the bloom filter.
    * @param {number} bloomFilter.nFlags - A set of flags that control how matched items
    * are added to the filter.
-   * @param {Object} [options]
+   * @param {object} [options]
    * @param {string} [options.fromBlockHash] - Specifies block hash to start syncing from
    * @param {number} [options.fromBlockHeight] - Specifies block height to start syncing from
    * @param {number} [options.count=0] - Number of blocks to sync,
@@ -436,9 +435,9 @@ class DAPIClient {
    *
    * @param {string} contractId
    * @param {string} type - Dap objects type to fetch
-   * @param options
-   * @param {Object} options.where - Mongo-like query
-   * @param {Object} options.orderBy - Mongo-like sort field
+   * @param {object} options
+   * @param {object} options.where - Mongo-like query
+   * @param {object} options.orderBy - Mongo-like sort field
    * @param {number} options.limit - how many objects to fetch
    * @param {number} options.startAt - number of objects to skip
    * @param {number} options.startAfter - exclusive skip


### PR DESCRIPTION
### Issue being fixed or implemented

There are some inconsistencies in our jsdoc comments. I made the following changes to help with some basic doc auto-generation I am investigating. 

### What was done

This PR fixes the minor whitespace/naming inconsistency in `src/index.js`. It also moves the class jsdoc as suggested [here](https://github.com/documentationjs/documentation/blob/master/docs/RECIPES.md#classes) (results in much cleaner output from documentation.js which I have been using to auto-generate [some documentation for evaluation](https://thephez.github.io/dapi-client-documentation.js/#dapiclient)).

### How Has This Been Tested?

No code changes to test

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
