### PR TITLE
feat: more types of errors to retry

### DIFF
--- a/src/RPCClient.js
+++ b/src/RPCClient.js
@@ -31,7 +31,7 @@ async function request(url, method, params, options = {}) {
   }
   const { data } = res;
   if (data.error) {
-    throw new RPCError(`DAPI RPC error: ${method}: ${data.error.message}`, data.error.data);
+    throw new RPCError(data.error.code, `DAPI RPC error: ${method}: ${data.error.message}`, data.error.data);
   }
   return data.result;
 }

--- a/src/errors/RPCError.js
+++ b/src/errors/RPCError.js
@@ -1,11 +1,13 @@
 class RPCError extends Error {
   /**
+   * @param {number} code
    * @param {string} message
    * @param {Object} [data]
    */
-  constructor(message, data = undefined) {
+  constructor(code, message, data = undefined) {
     super();
 
+    this.code = code;
     this.message = message;
     this.data = data;
     this.name = this.constructor.name;
@@ -13,6 +15,15 @@ class RPCError extends Error {
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);
     }
+  }
+
+  /**
+   * Get original error code
+   *
+   * @returns {number}
+   */
+  getCode() {
+    return this.code;
   }
 
   /**

--- a/src/transport/GrpcTransport.js
+++ b/src/transport/GrpcTransport.js
@@ -46,7 +46,8 @@ class GrpcTransport {
     } catch (e) {
       if (e.code !== GrpcErrorCodes.DEADLINE_EXCEEDED
             && e.code !== GrpcErrorCodes.UNAVAILABLE
-            && e.code !== GrpcErrorCodes.INTERNAL) {
+            && e.code !== GrpcErrorCodes.INTERNAL
+            && e.code !== GrpcErrorCodes.CANCELLED) {
         throw e;
       }
 

--- a/src/transport/JsonRpcTransport.js
+++ b/src/transport/JsonRpcTransport.js
@@ -39,7 +39,7 @@ class JsonRpcTransport {
       return result;
     } catch (e) {
       if (e.code !== 'ECONNABORTED' && e.code !== 'ECONNREFUSED'
-        && e.code !== -32603 && !(e.code >= -32000 && e.code <= -32099)) {
+            && e.code !== -32603 && !(e.code >= -32000 && e.code <= -32099)) {
         throw e;
       }
 

--- a/src/transport/JsonRpcTransport.js
+++ b/src/transport/JsonRpcTransport.js
@@ -38,7 +38,8 @@ class JsonRpcTransport {
 
       return result;
     } catch (e) {
-      if (e.code !== 'ECONNABORTED' && e.code !== 'ECONNREFUSED') {
+      if (e.code !== 'ECONNABORTED' && e.code !== 'ECONNREFUSED'
+        && e.code !== -32603 && !(e.code >= -32000 && e.code <= -32099)) {
         throw e;
       }
 

--- a/test/src/index.js
+++ b/test/src/index.js
@@ -292,7 +292,7 @@ describe('api', () => {
             if (address === validAddressWithoutOutputs) {
               return [];
             }
-            throw new RPCError('DAPI RPC error: getBlockHash: Error: Address not found');
+            throw new RPCError(-32602, 'DAPI RPC error: getBlockHash: Error: Address not found');
           }
           if (method === 'getAddressSummary') {
             return validAddressSummary;
@@ -304,7 +304,7 @@ describe('api', () => {
             if (height === 0) {
               return validBaseBlockHash;
             }
-            throw new RPCError('DAPI RPC error: getBlockHash: Error: Invalid block height');
+            throw new RPCError(-32602, 'DAPI RPC error: getBlockHash: Error: Invalid block height');
           }
           if (method === 'getMnListDiff') {
             if (baseBlockHash === validBaseBlockHash || config.nullHash && blockHash === validBlockHash) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- JSON RPC transport now retries requests to a different masternode in case of internal error and any server error
- gRPC transport now retries request to a different masternode  in case of any HTTP error received


## What was done?
<!--- Describe your changes in detail -->
- Error codes -32603 and a range of -32000 to -32099 are checked in JSON RPC transport
- Error code `CANCELLED` is checked in gRPC transport (which is thrown in case of any HTTP error)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using `mn-bootstrap` running custom pre-built image of `dapi` that is throwing errors in case of JSON RPC and returning HTTP error using NGINX in case of gRPC.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
