### PR TITLE
feat: timeout options for gRPC requests and simplified URL for gRPC client

### DIFF
--- a/lib/transport/GrpcTransport.js
+++ b/lib/transport/GrpcTransport.js
@@ -47,8 +47,16 @@ class GrpcTransport {
     const url = this.makeGrpcUrlFromAddress(address);
     const client = new ClientClass(url);
 
+    const requestOptions = {};
+    if (options.timeout !== undefined) {
+      requestOptions.deadline = new Date();
+      requestOptions.deadline.setMilliseconds(
+        requestOptions.deadline.getMilliseconds() + options.timeout,
+      );
+    }
+
     try {
-      const result = await client[method](requestMessage);
+      const result = await client[method](requestMessage, {}, requestOptions);
 
       this.lastUsedAddress = address;
 

--- a/lib/transport/GrpcTransport.js
+++ b/lib/transport/GrpcTransport.js
@@ -115,17 +115,18 @@ class GrpcTransport {
    * @returns {string}
    */
   makeGrpcUrlFromAddress(address) {
+    let port = address.getHttpPort();
+
     // For NodeJS Client
     if (typeof process !== 'undefined'
       && process.versions != null
       && process.versions.node != null) {
-      return `${address.getHost()}:${address.getGrpcPort()}`;
+      port = address.getGrpcPort();
     }
 
-    // For gRPC-Web client
     const protocol = address.getHttpPort() === 443 ? 'https' : 'http';
 
-    return `${protocol}://${address.getHost()}:${address.getHttpPort()}`;
+    return `${protocol}://${address.getHost()}:${port}`;
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using new `dapi-grpc`, passing `options` to every gRPC request, and using simplified URL.

## What was done?
<!--- Describe your changes in detail -->
- gRPC request is called with empty `meta` object, and `options` are being passed to every request
- URL passed as is, only `port` is different now

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
