### PR TITLE
fix: construct DAPIClient with local network option didn't work properly

### DIFF
--- a/lib/networkConfigs.js
+++ b/lib/networkConfigs.js
@@ -10,7 +10,7 @@ module.exports = {
     networkType: 'testnet',
   },
   local: {
-    address: '127.0.0.1',
+    addresses: ['127.0.0.1'],
     networkType: 'testnet',
   },
 };

--- a/test/unit/DAPIClient.spec.js
+++ b/test/unit/DAPIClient.spec.js
@@ -66,5 +66,23 @@ describe('DAPIClient', () => {
       expect(dapiClient.core).to.be.an.instanceOf(CoreMethodsFacade);
       expect(dapiClient.platform).to.be.an.instanceOf(PlatformMethodsFacade);
     });
+
+    it('should construct DAPIClient with network options', async () => {
+      options = {
+        retries: 3,
+        network: 'local',
+      };
+
+      dapiClient = new DAPIClient(options);
+      expect(dapiClient.options).to.deep.equal({
+        retries: 3,
+        network: 'local',
+        timeout: 2000,
+      });
+
+      expect(dapiClient.dapiAddressProvider).to.be.an.instanceOf(ListDAPIAddressProvider);
+      expect(dapiClient.core).to.be.an.instanceOf(CoreMethodsFacade);
+      expect(dapiClient.platform).to.be.an.instanceOf(PlatformMethodsFacade);
+    });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Construct DAPIClient with network option didn't work properly

## What was done?
Fixed local network config. Added new test.

## How Has This Been Tested?
Unit test

## Breaking Changes
No


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
