### PR TITLE
fix: 2 seconds timeout not enough for some requests

### DIFF
--- a/lib/DAPIClient.js
+++ b/lib/DAPIClient.js
@@ -13,7 +13,7 @@ class DAPIClient {
    */
   constructor(options = {}) {
     this.options = {
-      timeout: 2000,
+      timeout: 10000,
       retries: 3,
       ...options,
     };

--- a/test/unit/DAPIClient.spec.js
+++ b/test/unit/DAPIClient.spec.js
@@ -20,7 +20,7 @@ describe('DAPIClient', () => {
       expect(dapiClient.options).to.deep.equal({
         retries: 0,
         newOption: true,
-        timeout: 2000,
+        timeout: 10000,
       });
 
       expect(dapiClient.dapiAddressProvider).to.be.an.instanceOf(
@@ -36,7 +36,7 @@ describe('DAPIClient', () => {
 
       expect(dapiClient.options).to.deep.equal({
         retries: 3,
-        timeout: 2000,
+        timeout: 10000,
       });
 
       expect(dapiClient.dapiAddressProvider).to.be.an.instanceOf(
@@ -58,7 +58,7 @@ describe('DAPIClient', () => {
       expect(dapiClient.options).to.deep.equal({
         retries: 0,
         addresses: ['localhost'],
-        timeout: 2000,
+        timeout: 10000,
       });
 
       expect(dapiClient.dapiAddressProvider).to.be.an.instanceOf(ListDAPIAddressProvider);
@@ -77,7 +77,7 @@ describe('DAPIClient', () => {
       expect(dapiClient.options).to.deep.equal({
         retries: 3,
         network: 'local',
-        timeout: 2000,
+        timeout: 10000,
       });
 
       expect(dapiClient.dapiAddressProvider).to.be.an.instanceOf(ListDAPIAddressProvider);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Default timeout was increased to 10 seconds, as a temporary solution for breaking tests


## What was done?
Default timeout was increased to 10 seconds


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
