### PR TITLE
fix: remove timeout from default options in subscribeToTransactionsWithProofs method

### DIFF
--- a/lib/methods/core/subscribeToTransactionsWithProofsFactory.js
+++ b/lib/methods/core/subscribeToTransactionsWithProofsFactory.js
@@ -28,6 +28,7 @@ function subscribeToTransactionsWithProofsFactory(grpcTransport) {
   async function subscribeToTransactionsWithProofs(bloomFilter, options = { }) {
     // eslint-disable-next-line no-param-reassign
     options = {
+      timeout: undefined,
       count: 0,
       ...options,
     };

--- a/test/unit/methods/core/subscribeToTransactionsWithProofsFactory.spec.js
+++ b/test/unit/methods/core/subscribeToTransactionsWithProofsFactory.spec.js
@@ -61,7 +61,10 @@ describe('subscribeToTransactionsWithProofsFactory', () => {
       TransactionsFilterStreamPromiseClient,
       'subscribeToTransactionsWithProofs',
       request,
-      options,
+      {
+        timeout: undefined,
+        ...options,
+      },
     );
 
     expect(actualStream).to.be.equal(stream);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
subscribeToTransactionsWithProofs breaks after defined timeout 

## What was done?
Removed timeout from default options in subscribeToTransactionsWithProofs method


## How Has This Been Tested?
Unit tests


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
