### PR TITLE
fix: JSON RPC doesn't retry on `ETIMEDOUT`

### DIFF
--- a/src/transport/JsonRpcTransport.js
+++ b/src/transport/JsonRpcTransport.js
@@ -38,7 +38,7 @@ class JsonRpcTransport {
 
       return result;
     } catch (e) {
-      if (e.code !== 'ECONNABORTED' && e.code !== 'ECONNREFUSED'
+      if (e.code !== 'ECONNABORTED' && e.code !== 'ECONNREFUSED' && e.code !== 'ETIMEDOUT'
             && e.code !== -32603 && !(e.code >= -32000 && e.code <= -32099)) {
         throw e;
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is a hotfix for retry logic. We should retry on `ETIMEDOUT` status.

## What was done?
<!--- Describe your changes in detail -->
Added `ETIMEDOUT` to a list of errors to retry.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
