### PR TITLE
fix: ambiguity in `addresses` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Custom addresses may be directly specified in cases where it is beneficial to kn
 const DAPIClient = require('@dashevo/dapi-client');
 
 var client = new DAPIClient({
-  addresses: [
+  dapiAddresses: [
     '127.0.0.1',
     '127.0.0.2'
   ],
@@ -90,7 +90,7 @@ const DAPIClient = require('@dashevo/dapi-client');
 
 // Set options to direct the request to a specific address and disable retries
 const options = {
-  addresses: ['127.0.0.1'],
+  dapiAddresses: ['127.0.0.1'],
   retries: 0,
 };
 

--- a/lib/DAPIClient.js
+++ b/lib/DAPIClient.js
@@ -42,7 +42,7 @@ class DAPIClient {
 /**
  * @typedef {DAPIClientOptions} DAPIClientOptions
  * @property {DAPIAddressProvider} [dapiAddressProvider]
- * @property {Array<RawDAPIAddress|DAPIAddress|string>} [addresses]
+ * @property {Array<RawDAPIAddress|DAPIAddress|string>} [dapiAddresses]
  * @property {string[]|RawDAPIAddress[]} [seeds]
  * @property {string|Network} [network=evonet]
  * @property {number} [timeout=2000]

--- a/lib/dapiAddressProvider/createDAPIAddressProviderFromOptions.js
+++ b/lib/dapiAddressProvider/createDAPIAddressProviderFromOptions.js
@@ -30,8 +30,8 @@ function createDAPIAddressProviderFromOptions(options) {
   }
 
   if (options.dapiAddressProvider) {
-    if (options.addresses) {
-      throw new DAPIClientError("Can't use 'address' with 'dapiAddressProvider' option");
+    if (options.dapiAddresses) {
+      throw new DAPIClientError("Can't use 'dapiAddresses' with 'dapiAddressProvider' option");
     }
 
     if (options.seeds) {
@@ -41,13 +41,13 @@ function createDAPIAddressProviderFromOptions(options) {
     return options.dapiAddressProvider;
   }
 
-  if (options.addresses) {
+  if (options.dapiAddresses) {
     if (options.seeds) {
-      throw new DAPIClientError("Can't use 'seeds' with 'addresses' option");
+      throw new DAPIClientError("Can't use 'seeds' with 'dapiAddresses' option");
     }
 
     return new ListDAPIAddressProvider(
-      options.addresses.map((rawAddress) => new DAPIAddress(rawAddress)),
+      options.dapiAddresses.map((rawAddress) => new DAPIAddress(rawAddress)),
       options,
     );
   }

--- a/lib/networkConfigs.js
+++ b/lib/networkConfigs.js
@@ -10,7 +10,7 @@ module.exports = {
     network: 'evonet',
   },
   local: {
-    addresses: ['127.0.0.1'],
+    dapiAddresses: ['127.0.0.1'],
     network: 'regtest',
   },
 };

--- a/test/unit/DAPIClient.spec.js
+++ b/test/unit/DAPIClient.spec.js
@@ -52,14 +52,14 @@ describe('DAPIClient', () => {
     it('should construct DAPIClient with address options', async () => {
       options = {
         retries: 0,
-        addresses: ['localhost'],
+        dapiAddresses: ['localhost'],
       };
 
       dapiClient = new DAPIClient(options);
 
       expect(dapiClient.options).to.deep.equal({
         retries: 0,
-        addresses: ['localhost'],
+        dapiAddresses: ['localhost'],
         network: 'evonet',
         timeout: 10000,
       });

--- a/test/unit/dapiAddressProvider/createDAPIAddressProviderFromOptions.spec.js
+++ b/test/unit/dapiAddressProvider/createDAPIAddressProviderFromOptions.spec.js
@@ -29,7 +29,7 @@ describe('createDAPIAddressProviderFromOptions', () => {
     });
 
     it('should throw DAPIClientError if `addresses` option is passed too', async () => {
-      options.addresses = ['localhost'];
+      options.dapiAddresses = ['localhost'];
 
       try {
         createDAPIAddressProviderFromOptions(options);
@@ -58,7 +58,7 @@ describe('createDAPIAddressProviderFromOptions', () => {
 
     beforeEach(() => {
       options = {
-        addresses: ['localhost'],
+        dapiAddresses: ['localhost'],
         network: 'local',
       };
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is an ambiguity in option name - `addresses`

## What was done?
<!--- Describe your changes in detail -->
Renamed option to `dapiAddresses`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
`addresses` `DAPIClient` option is now called `dapiAddresses`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
