### PR TITLE
feat: add ports to string representation of DAPIAddress

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ const DAPIClient = require('@dashevo/dapi-client');
 
 var client = new DAPIClient({
   addresses: [
-    '127.0.0.1',
-    '127.0.0.2'
+    '127.0.0.1:3000:3010',
+    '127.0.0.2:3000:3010'
   ],
 });
 

--- a/lib/dapiAddressProvider/DAPIAddress.js
+++ b/lib/dapiAddressProvider/DAPIAddress.js
@@ -10,11 +10,13 @@ class DAPIAddress {
     }
 
     if (typeof address === 'string') {
+      const [host, httpPort, grpcPort] = address.split(':');
+
       // eslint-disable-next-line no-param-reassign
       address = {
-        host: address,
-        httpPort: DAPIAddress.DEFAULT_HTTP_PORT,
-        grpcPort: DAPIAddress.DEFAULT_GRPC_PORT,
+        host,
+        httpPort: httpPort ? parseInt(httpPort, 10) : DAPIAddress.DEFAULT_HTTP_PORT,
+        grpcPort: grpcPort ? parseInt(grpcPort, 10) : DAPIAddress.DEFAULT_GRPC_PORT,
       };
     }
 
@@ -155,11 +157,15 @@ class DAPIAddress {
    */
   toJSON() {
     return {
-      host: this.host,
-      httpPort: this.httpPort,
-      grpcPort: this.grpcPort,
-      proRegTxHash: this.proRegTxHash,
+      host: this.getHost(),
+      httpPort: this.getHttpPort(),
+      grpcPort: this.getGrpcPort(),
+      proRegTxHash: this.getProRegTxHash(),
     };
+  }
+
+  toString() {
+    return `${this.getHost()}:${this.getHttpPort()}:${this.getGrpcPort()}`;
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Passing not just host but ports as part of the string address string representation will be very convenient for usage.

## What was done?
<!--- Describe your changes in detail -->
* Parse HTTP and gRPC ports from address string.
* Add `DAPIAddress#toString` that returns the address string representation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
