### PR TITLE
fix: internal error when submitting `fromBlockHeight` as 0 to `subscribeToTransactionsWithProofs`

### DIFF
--- a/lib/methods/core/subscribeToTransactionsWithProofsFactory.js
+++ b/lib/methods/core/subscribeToTransactionsWithProofsFactory.js
@@ -4,6 +4,8 @@ const {
   BloomFilter: BloomFilterMessage,
 } = require('@dashevo/dapi-grpc');
 
+const DAPIClientError = require('../../errors/DAPIClientError');
+
 /**
  * @param {GrpcTransport} grpcTransport
  * @returns {subscribeToTransactionsWithProofs}
@@ -35,6 +37,10 @@ function subscribeToTransactionsWithProofsFactory(grpcTransport) {
       ...options,
     };
 
+    if (options.fromBlockHeight === 0) {
+      throw new DAPIClientError('Invalid argument: minimum value for `fromBlockHeight` is 1');
+    }
+
     const bloomFilterMessage = new BloomFilterMessage();
 
     let { vData } = bloomFilter;
@@ -51,7 +57,7 @@ function subscribeToTransactionsWithProofsFactory(grpcTransport) {
     const request = new TransactionsWithProofsRequest();
     request.setBloomFilter(bloomFilterMessage);
 
-    if (options.fromBlockHeight) {
+    if (options.fromBlockHeight !== undefined) {
       request.setFromBlockHeight(options.fromBlockHeight);
     }
 

--- a/test/unit/methods/core/subscribeToTransactionsWithProofsFactory.spec.js
+++ b/test/unit/methods/core/subscribeToTransactionsWithProofsFactory.spec.js
@@ -10,6 +10,8 @@ const {
 
 const subscribeToTransactionsWithProofsFactory = require('../../../../lib/methods/core/subscribeToTransactionsWithProofsFactory');
 
+const DAPIClientError = require('../../../../lib/errors/DAPIClientError');
+
 describe('subscribeToTransactionsWithProofsFactory', () => {
   let subscribeToTransactionsWithProofs;
   let grpcTransportMock;
@@ -91,5 +93,25 @@ describe('subscribeToTransactionsWithProofsFactory', () => {
     );
 
     expect(actualStream).to.be.equal(stream);
+  });
+
+  it('should throw error if `fromBlockHeight` is set to 0', async () => {
+    options = {
+      fromBlockHeight: 0,
+      count: 5,
+      fromBlockHash: '000000000b0339e07bce8b3186a6a57a3c45d10e16c4bce18ef81b667bc822b2',
+      timeout: 150000,
+    };
+
+    const bloomFilter = BloomFilter.create(1, 0.001);
+
+    try {
+      await subscribeToTransactionsWithProofs(
+        bloomFilter, options,
+      );
+    } catch (e) {
+      expect(e).to.be.an.instanceOf(DAPIClientError);
+      expect(e.message).to.equal('Invalid argument: minimum value for `fromBlockHeight` is 1');
+    }
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Internal error is thrown when `options.fromBlockHeight` is submitted as `0` to `subscribeToTransactionsWithProofs`

## What was done?
<!--- Describe your changes in detail -->
Added assertions for `fromBlockHeight` value to be more then 0

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
