### PR TITLE
feat!: rename sendTransaction and applyStateTransition to broadcast

### DIFF
--- a/lib/methods/core/broadcastTransactionFactory.js
+++ b/lib/methods/core/broadcastTransactionFactory.js
@@ -1,6 +1,6 @@
 const {
   CorePromiseClient,
-  SendTransactionRequest,
+  BroadcastTransactionRequest,
 } = require('@dashevo/dapi-grpc');
 
 /**
@@ -17,15 +17,15 @@ function broadcastTransactionFactory(grpcTransport) {
    * @returns {string}
    */
   async function broadcastTransaction(transaction, options = {}) {
-    const sendTransactionRequest = new SendTransactionRequest();
-    sendTransactionRequest.setTransaction(transaction);
-    sendTransactionRequest.setAllowHighFees(options.allowHighFees || false);
-    sendTransactionRequest.setBypassLimits(options.bypassLimits || false);
+    const broadcastTransactionRequest = new BroadcastTransactionRequest();
+    broadcastTransactionRequest.setTransaction(transaction);
+    broadcastTransactionRequest.setAllowHighFees(options.allowHighFees || false);
+    broadcastTransactionRequest.setBypassLimits(options.bypassLimits || false);
 
     const response = await grpcTransport.request(
       CorePromiseClient,
-      'sendTransaction',
-      sendTransactionRequest,
+      'broadcastTransaction',
+      broadcastTransactionRequest,
       options,
     );
 

--- a/lib/methods/platform/broadcastStateTransitionFactory.js
+++ b/lib/methods/platform/broadcastStateTransitionFactory.js
@@ -1,5 +1,5 @@
 const {
-  ApplyStateTransitionRequest,
+  BroadcastStateTransitionRequest,
   PlatformPromiseClient,
 } = require('@dashevo/dapi-grpc');
 
@@ -14,16 +14,16 @@ function broadcastStateTransitionFactory(grpcTransport) {
    * @typedef {broadcastStateTransition}
    * @param {Buffer} stateTransition
    * @param {DAPIClientOptions} [options]
-   * @returns {Promise<!ApplyStateTransitionResponse>}
+   * @returns {Promise<!BroadcastStateTransitionResponse>}
    */
   async function broadcastStateTransition(stateTransition, options = {}) {
-    const applyStateTransitionRequest = new ApplyStateTransitionRequest();
-    applyStateTransitionRequest.setStateTransition(stateTransition);
+    const broadcastStateTransitionRequest = new BroadcastStateTransitionRequest();
+    broadcastStateTransitionRequest.setStateTransition(stateTransition);
 
     return grpcTransport.request(
       PlatformPromiseClient,
-      'applyStateTransition',
-      applyStateTransitionRequest,
+      'broadcastStateTransition',
+      broadcastStateTransitionRequest,
       options,
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -355,15 +355,15 @@
       }
     },
     "@dashevo/dapi-grpc": {
-      "version": "0.14.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.14.0-dev.1.tgz",
-      "integrity": "sha512-o5l5nH7ZuIMv9fSOScy6orPyAxTR//EsxMP3SGfrybCOf0fjS2FttlbHGdMbC5A21a/Og4ms1zQgf0QquaFfgw==",
+      "version": "0.15.0-dev.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.15.0-dev.1.tgz",
+      "integrity": "sha512-2yfLGF3UsVmYRfbKsTRqI9NbL+gS9zF0J5iypiqgeEK4foDRV3zfhwGBGorJq9SWdYc+n7AtVS1OhFICkstIkw==",
       "requires": {
         "@dashevo/grpc-common": "^0.3.0",
-        "google-protobuf": "^3.8.0",
-        "grpc": "^1.24.2",
-        "grpc-web": "^1.0.6",
-        "protobufjs": "^6.8.8"
+        "google-protobuf": "^3.12.2",
+        "grpc": "^1.24.3",
+        "grpc-web": "^1.1.0",
+        "protobufjs": "^6.9.0"
       }
     },
     "@dashevo/dashcore-lib": {
@@ -425,9 +425,9 @@
       "integrity": "sha512-3vvnZweBca4URBXHF+FTrM4sdTpp3IMt73G1zUKQEdYm/kJkIKN94qpFai7YZDl87k64RCH+ckRZk6ruQPz5KQ=="
     },
     "@grpc/proto-loader": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.4.tgz",
-      "integrity": "sha512-HTM4QpI9B2XFkPz7pjwMyMgZchJ93TVkL3kWPW8GDMDKYxsMnmf4w2TNMJK7+KNiYHS5cJrCEAFlF+AwtXWVPA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.5.tgz",
+      "integrity": "sha512-WwN9jVNdHRQoOBo9FDH7qU+mgfjPc8GygPYms3M+y3fbQLfnCe/Kv/E01t7JRgnrsOHH8euvSbed3mIalXhwqQ==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "protobufjs": "^6.8.6"
@@ -632,9 +632,9 @@
       "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
     },
     "@types/node": {
-      "version": "13.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.10.tgz",
-      "integrity": "sha512-J+FbkhLTcFstD7E5mVZDjYxa1VppwT2HALE6H3n2AnBSP8uiCQk0Pyr6BkJcP38dFV9WecoVJRJmFnl9ikIW7Q=="
+      "version": "13.13.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.14.tgz",
+      "integrity": "sha512-Az3QsOt1U/K1pbCQ0TXGELTuTkPLOiFIQf3ILzbOyo0FqgV9SxRnxbxM5QlAveERZMHpZY+7u3Jz2tKyl+yg6g=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -3795,9 +3795,9 @@
       }
     },
     "grpc-web": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.1.0.tgz",
-      "integrity": "sha512-oPoS4/E/EO0TA2ZOSf3AxV2AbWDeabwfbAo+8oXNenOw87RmKz4hME8Sy4KDu2dUnqK8cuGfzdQlJPAEQEygNQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.2.0.tgz",
+      "integrity": "sha512-QS0RF+xiWnMEiHWyA0A0I8JYYJLOiF/DGEpRQ7vJDOzEZYfmNqI7d7d29sYBbNfTi+arVh2JpeGIX7ch24a+tA=="
     },
     "has": {
       "version": "1.0.3",
@@ -5159,9 +5159,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -7091,9 +7091,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
-      "integrity": "sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
+      "integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     }
   ],
   "dependencies": {
-    "@dashevo/dapi-grpc": "~0.14.0-dev.1",
+    "@dashevo/dapi-grpc": "~0.15.0-dev.1",
     "@dashevo/dashcore-lib": "~0.18.11",
     "axios": "^0.19.2",
     "cbor": "^5.0.1",

--- a/test/integration/methods/core/CoreMethodsFacade.spec.js
+++ b/test/integration/methods/core/CoreMethodsFacade.spec.js
@@ -1,7 +1,7 @@
 const { EventEmitter } = require('events');
 
 const {
-  SendTransactionResponse,
+  BroadcastTransactionResponse,
   GetBlockResponse,
   GetTransactionResponse,
   GetStatusResponse,
@@ -29,7 +29,7 @@ describe('CoreMethodsFacade', () => {
 
   describe('#broadcastTransaction', () => {
     it('should broadcast transaction', async () => {
-      const response = new SendTransactionResponse();
+      const response = new BroadcastTransactionResponse();
       response.setTransactionId('4f46066bd50cc2684484407696b7949e82bd906ea92c040f59a97cba47ed8176');
       grpcTransportMock.request.resolves(response);
 

--- a/test/integration/methods/platform/PlatformMethodsFacade.spec.js
+++ b/test/integration/methods/platform/PlatformMethodsFacade.spec.js
@@ -4,7 +4,7 @@ const {
   GetIdentityByFirstPublicKeyResponse,
   GetIdentityResponse,
   GetIdentityIdByFirstPublicKeyResponse,
-  ApplyStateTransitionResponse,
+  BroadcastStateTransitionResponse,
 } = require('@dashevo/dapi-grpc');
 const DashPlatformProtocol = require('@dashevo/dpp');
 
@@ -26,7 +26,7 @@ describe('PlatformMethodsFacade', () => {
 
   describe('#broadcastStateTransition', () => {
     it('should broadcast state transition', async () => {
-      const response = new ApplyStateTransitionResponse();
+      const response = new BroadcastStateTransitionResponse();
       grpcTransportMock.request.resolves(response);
 
       const dpp = new DashPlatformProtocol();

--- a/test/unit/methods/core/broadcastTransactionFactory.spec.js
+++ b/test/unit/methods/core/broadcastTransactionFactory.spec.js
@@ -1,7 +1,7 @@
 const {
   CorePromiseClient,
-  SendTransactionRequest,
-  SendTransactionResponse,
+  BroadcastTransactionRequest,
+  BroadcastTransactionResponse,
 } = require('@dashevo/dapi-grpc');
 
 const broadcastTransactionFactory = require(
@@ -28,7 +28,7 @@ describe('broadcastTransactionFactory', () => {
   });
 
   it('should return transaction id', async () => {
-    const response = new SendTransactionResponse();
+    const response = new BroadcastTransactionResponse();
     response.setTransactionId(id);
     grpcTransportMock.request.resolves(response);
 
@@ -41,14 +41,14 @@ describe('broadcastTransactionFactory', () => {
       options,
     );
 
-    const request = new SendTransactionRequest();
+    const request = new BroadcastTransactionRequest();
     request.setTransaction(transaction);
     request.setAllowHighFees(options.allowHighFees);
     request.setBypassLimits(false);
 
     expect(grpcTransportMock.request).to.be.calledOnceWithExactly(
       CorePromiseClient,
-      'sendTransaction',
+      'broadcastTransaction',
       request,
       options,
     );

--- a/test/unit/methods/platform/broadcastStateTransitionFactory.spec.js
+++ b/test/unit/methods/platform/broadcastStateTransitionFactory.spec.js
@@ -1,6 +1,6 @@
 const {
-  ApplyStateTransitionRequest,
-  ApplyStateTransitionResponse,
+  BroadcastStateTransitionRequest,
+  BroadcastStateTransitionResponse,
   PlatformPromiseClient,
 } = require('@dashevo/dapi-grpc');
 
@@ -18,7 +18,7 @@ describe('broadcastStateTransitionFactory', () => {
   let response;
 
   beforeEach(function beforeEach() {
-    response = new ApplyStateTransitionResponse();
+    response = new BroadcastStateTransitionResponse();
 
     grpcTransportMock = {
       request: this.sinon.stub().resolves(response),
@@ -38,12 +38,12 @@ describe('broadcastStateTransitionFactory', () => {
   it('should broadcast state transition', async () => {
     const result = await broadcastStateTransition(stateTransitionFixture, options);
 
-    const request = new ApplyStateTransitionRequest();
+    const request = new BroadcastStateTransitionRequest();
     request.setStateTransition(stateTransitionFixture);
 
     expect(grpcTransportMock.request).to.be.calledOnceWithExactly(
       PlatformPromiseClient,
-      'applyStateTransition',
+      'broadcastStateTransition',
       request,
       options,
     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to more accurately name DAPI and DAPI gRPC endpoints we need to rename sendTransaction and applyStateTransition methods.

## What was done?
<!--- Describe your changes in detail -->
dapi-grpc updated to 0.15.0-dev.1
Updated dapi-grpc class names
Updated DAPI method names

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
This version is incompatible with DAPI and dapi-grpc lover than 0.15.0-dev-1

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
